### PR TITLE
Adding macos runners to the workflow jobs #2828

### DIFF
--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -11,11 +11,12 @@ on:
 jobs:
   # Testing to be run on Linux distros
   build:
-    runs-on: ubuntu-latest
-    # what versions of the run times need to be tested
-    strategy:
+    strategy: 
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        os-version: [ubuntu-latest, macos-latest] # windows-latest,
+        python-version: ["3.11", "3.12", "3.13"]    
+    runs-on: ${{ matrix.os-version }}
+    
     steps:
     
     # Getting git code base

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
     
     # Creating the python environment
-    - name: Set up Python Environment ${{ matrix.python-version }}
+    - name: Set up Python Environment ${{ matrix.python-version }} on ${{ matrix.os-version }} runner
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
This adds adds `os-version` to the `stratagy.matrix `  to allow the automatic iteration though different os.
 - `macos` added to the `os-version` matrix
 - python version `3.10` was removed from the python-versions as it causes issues with macos
 - python version `3.13` was added to `python-versions` cause it is the most recent version which may have some compatibility issues that are yet to show up
 - added `matrix.os-version` to the `Set up python environment` to help help with clarity on which `os-version` the runner is setting up the `python-version`

## Summary by Sourcery

Update GitHub Actions workflow to support macOS runners and update Python versions

CI:
- Modify UnitTesting workflow to add macOS as a test runner alongside Ubuntu
- Update Python version matrix to include 3.11, 3.12, and 3.13, removing 3.10