### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pymedphys = { extras = ["all"], version = "^0.41.0", python = ">=3.10,<3.13" }
 #    { version = "==3.0.1", python = "<3.10"},
 #    { version = "==3.0.1", python = ">=3.10"}
 #]
-# pyside6 = { version = ">=6.4.0,<6.9", python =">=3.10,<3.13" }
+pyside6 = { version = ">=6.4.0,<6.9", python =">=3.10,<3.13" }
 vtk = "*"
 # shapely 1.8.3 through 1.8.5.post1 have build failures. v2.0 has API changes.
 shapely = ">=2.0"
@@ -60,7 +60,7 @@ pytest-cov = "*"
 pytest-pylint = "*"
 pytest-isort = "*"
 pytest-mypy = "*"
-# pytest-qt = "*"
+pytest-qt = "*"
 pytest-timeout = "*"
 flake8 = "*"
 


### PR DESCRIPTION
Uncommented pyside6 and pytest-qt

## Summary by Sourcery

Build:
- Enable `pyside6` and `pytest-qt` dependencies.