### PR TITLE
Created unit tests for dicom_utils & input and output

### DIFF
--- a/src/inputs_and_outputs.py
+++ b/src/inputs_and_outputs.py
@@ -3,7 +3,7 @@ This file is used to open the dicom image, if it cant be opened it will throw er
 """
 
 import numpy as np
-from dicom_utils import numpy_to_qimage
+from src.dicom_utils import numpy_to_qimage
 
 #Todo Image is not loading if the image is anything other than 2D
 def get_qimage_from_dicom_file(ds):

--- a/src/mini_project_ui.py
+++ b/src/mini_project_ui.py
@@ -135,7 +135,11 @@ class MiniProjectUI(QtWidgets.QDialog):
             ds = read_dicom_file(self.path)
 
             #Adds the validation needed for AXIAL files and "StudyID+StudyDescription"
-            validate_dicom(ds)
+            if ds is not None:
+                validate_dicom(ds)
+            else:
+                logging.error("validate_dicom failed")
+                raise ValueError("Invalid DICOM file or failed to load the file.")
 
             if ds is not None:
                 self.save_directory_path()

--- a/src/mini_project_ui.py
+++ b/src/mini_project_ui.py
@@ -6,7 +6,7 @@ from PySide6 import QtWidgets
 from PySide6.QtGui import QPixmap, QImage
 from PySide6.QtCore import QTimer
 from inputs_and_outputs import get_qimage_from_dicom_file
-from dicom_utils import extract_patient_info
+from dicom_utils import extract_patient_info, validate_dicom
 from read_dicom_file import read_dicom_file
 from babel.dates import format_date
 import os
@@ -132,8 +132,11 @@ class MiniProjectUI(QtWidgets.QDialog):
     def open_dicom_file(self):
         """Opens a DICOM file and displays the image linked to that file, if available"""
         try:
-
             ds = read_dicom_file(self.path)
+
+            #Adds the validation needed for AXIAL files and "StudyID+StudyDescription"
+            validate_dicom(ds)
+
             if ds is not None:
                 self.save_directory_path()
             else:
@@ -143,6 +146,7 @@ class MiniProjectUI(QtWidgets.QDialog):
             self.file_cannot_be_opened_error()
 
         self.text.setText(self.path)
+
 
         metadata = extract_patient_info(ds)
 

--- a/tests/test_dicom_utils.py
+++ b/tests/test_dicom_utils.py
@@ -1,0 +1,265 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+from pydicom.dataset import Dataset
+from pydicom.multival import MultiValue
+from src import dicom_utils
+
+#dummy class
+class DummyPatient:
+    def __init__(self, given_name=None, family_name=None):
+        self.given_name = given_name
+        self.family_name = family_name
+
+#tests for extracting patient information
+def test_extract_patient_info_anonymous():
+    """THis method is for a dummy patient that has a UUID for a name"""
+    ds = {
+        "PatientName": "123e4567-e89b-12d3-a456-426614174000",  # Simulate UUID
+        "PatientBirthDate": None,
+        "Modality": "CT"
+    }
+    with patch("src.dicom_utils._is_uuid", return_value=True):
+        info = dicom_utils.extract_patient_info(ds)
+    assert info.given_name == "Anonymous"
+    assert info.family_name == "Anonymous"
+    assert info.patient_id == "Anonymous"
+    assert info.sex == "Anonymous"
+    assert info.birth_date is None
+    assert info.modality == "CT"
+
+
+def test_extract_patient_info_with_details():
+    """This method is for a dummy patient with valid inputs"""
+    ds = {
+        "PatientName": DummyPatient(given_name="John", family_name="Doe"),
+        "PatientID": "P123",
+        "PatientSex": "M",
+        "PatientBirthDate": "19800101",
+        "Modality": "MR"
+    }
+    with patch("src.dicom_utils._is_uuid", return_value=False):
+        info = dicom_utils.extract_patient_info(ds)
+    assert info.given_name == "John"
+    assert info.family_name == "Doe"
+    assert info.patient_id == "P123"
+    assert info.sex == "M"
+    assert info.birth_date == datetime.strptime("19800101", "%Y%m%d").date()
+    assert info.modality == "MR"
+
+def test_extract_patient_info_invalid_birthdate():
+    """This method is for a dummy patient with invalid inputs"""
+    ds = {
+        "PatientName": DummyPatient(given_name="Jane", family_name="Smith"),
+        "PatientID": "P456",
+        "PatientSex": "F",
+        "PatientBirthDate": "notadate",
+        "Modality": "CT"
+    }
+    with patch("src.dicom_utils._is_uuid", return_value=False):
+        info = dicom_utils.extract_patient_info(ds)
+    assert info.birth_date is None
+
+def test_extract_patient_info_missing_fields():
+    """This method is for a dummy patient with missing fields
+    Namely the birthdate, also name is forced to not be a UUID"""
+    ds = {}
+    with patch("src.dicom_utils._is_uuid", return_value=True):
+        info = dicom_utils.extract_patient_info(ds)
+    assert info.given_name == "Anonymous"
+    assert info.family_name == "Anonymous"
+    assert info.patient_id == "Anonymous"
+    assert info.sex == "Anonymous"
+    assert info.birth_date is None
+    assert info.modality == "Unknown"
+
+def test_extract_patient_info_non_uuid_name():
+    """Test extract_patient_info with a non-UUID PatientName"""
+    ds = {
+    "PatientName": MagicMock(given_name="John", family_name="Doe"),
+    "PatientBirthDate": "19801001",
+    "Modality": "CT",
+    "PatientID": "JD123",
+    "PatientSex": "M"
+    }
+    #No patching _is_uuid, needs to be treated as normal name
+    info = dicom_utils.extract_patient_info(ds)
+    assert info.given_name == "John"
+    assert info.family_name == "Doe"
+    assert info.patient_id == "JD123"
+    assert info.sex == "M"
+    assert info.birth_date == datetime.strptime("19801001", "%Y%m%d").date()
+    assert info.modality == "CT"
+
+#Anything below is tests for validate_dicom method
+
+@pytest.mark.parametrize(
+    #bunch of data that should pass as they have AXIAL, no localiser or CT
+    "study_id, study_desc, image_type, modality, expected",
+    [
+        # Happy path: string ImageType, not LOCALIZER, not CT
+        ("123", "desc", "SAGITTAL", "MR", True),
+        # Happy path: MultiValue ImageType, not LOCALIZER, not CT
+        ("456", "desc2", MultiValue(str, ["AXIAL", "SOMETHING"]), "MR", True),
+        # Happy path: list ImageType, not LOCALIZER, not CT
+        ("789", "desc3", ["AXIAL", "SOMETHING"], "MR", True),
+        # Happy path: CT, AXIAL present
+        ("321", "desc4", ["AXIAL", "SOMETHING"], "CT", True),
+        # Happy path: CT, AXIAL present (case-insensitive)
+        ("654", "desc5", ["axial", "other"], "ct", True),
+    ],
+    ids=[
+        "string_ImageType_MR",
+        "MultiValue_ImageType_MR",
+        "list_ImageType_MR",
+        "CT_AXIAL_present",
+        "CT_AXIAL_present_case_insensitive",
+    ]
+)
+
+def test_validate_dicom_happy_paths(study_id, study_desc, image_type, modality, expected):
+    """Pytest function that verifies that dicom happy paths work, and will return
+    true for a variety of valid dicom dataset senerios"""
+    # Arrange
+    ds = Dataset()
+    ds.StudyID = study_id
+    ds.StudyDescription = study_desc
+    ds.ImageType = image_type
+    ds.Modality = modality
+
+    # Act
+    result = dicom_utils.validate_dicom(ds)
+
+    # Assert
+    assert result is expected
+    
+@pytest.mark.parametrize(
+    #Examples that are missing studyID || studyDescription
+    "missing_field, expected_exc, expected_msg",
+    [
+        ("StudyID", ValueError, "Missing required DICOM fields: StudyID"),
+        ("StudyDescription", ValueError, "Missing required DICOM fields: StudyDescription"),
+    ],
+    ids=["missing_StudyID", "missing_StudyDescription"]
+)
+
+def test_validate_dicom_missing_required_fields(missing_field, expected_exc, expected_msg):
+    """This method raises an exception when required fields are missing"""
+    # Arrange
+    ds = Dataset()
+    # sourcery skip: no-conditionals-in-tests
+    if missing_field != "StudyID":
+        ds.StudyID = "123"
+    if missing_field != "StudyDescription":
+        ds.StudyDescription = "desc"
+    ds.ImageType = "AXIAL"
+    ds.Modality = "MR"
+
+    # Act & Assert
+    with pytest.raises(expected_exc) as excinfo:
+        dicom_utils.validate_dicom(ds)
+    assert expected_msg in str(excinfo.value)
+
+@pytest.mark.parametrize(
+    "image_type, expected_exc, expected_msg",
+    [
+        ("LOCALIZER", ValueError, "Skipping LOCALIZER image."),
+        (["LOCALIZER", "AXIAL"], ValueError, "Skipping LOCALIZER image."),
+        (MultiValue(str, ["localizer", "axial"]), ValueError, "Skipping LOCALIZER image."),
+    ],
+    ids=["string_LOCALIZER", "list_LOCALIZER", "MultiValue_LOCALIZER"]
+)
+
+def test_validate_dicom_localizer_image(image_type, expected_exc, expected_msg):
+    """This method raises an exception when image type is invalid"""
+    # Arrange
+    ds = Dataset()
+    ds.StudyID = "123"
+    ds.StudyDescription = "desc"
+    ds.ImageType = image_type
+    ds.Modality = "MR"
+
+    # Act & Assert
+    with pytest.raises(expected_exc) as excinfo:
+        dicom_utils.validate_dicom(ds)
+    assert expected_msg in str(excinfo.value)
+
+@pytest.mark.parametrize(
+   "image_type, modality, expected_exc, expected_msg",
+    [
+        (["SOMETHING"], "CT", ValueError, "Skipping non-AXIAL CT image."),
+        (["CORONAL", "SOMETHING"], "CT", ValueError, "Skipping non-AXIAL CT image."),
+        ("CORONAL", "CT", ValueError, "Skipping non-AXIAL CT image."),
+        (MultiValue(str, ["CORONAL", "SOMETHING"]), "CT", ValueError, "Skipping non-AXIAL CT image."),
+    ],
+    ids=[
+        "list_non_AXIAL_CT",
+        "list_CORONAL_CT",
+        "string_CORONAL_CT",
+        "MultiValue_CORONAL_CT"
+    ]
+)
+
+def test_validate_dicom_non_axial_ct(image_type, modality, expected_exc, expected_msg):
+    """This test is testing the Skipping non-AXIAL CT image by putting something that is not AXIAL
+    Also putting in multiple options per one"""
+    # Arrange
+    ds = Dataset()
+    ds.StudyID = "123"
+    ds.StudyDescription = "desc"
+    ds.ImageType = image_type
+    ds.Modality = modality
+
+    # Act & Assert
+    with pytest.raises(expected_exc) as excinfo:
+        dicom_utils.validate_dicom(ds)
+    assert expected_msg in str(excinfo.value)
+
+@pytest.mark.parametrize(
+    "image_type, expected_exc, expected_msg",
+    [
+        (123, ValueError, "Unexpected ImageType format: <class 'int'>"),
+        (None, ValueError, "Unexpected ImageType format: <class 'NoneType'>"),
+        (object(), ValueError, "Unexpected ImageType format: <class 'object'>"),
+    ],
+    ids=["int_ImageType", "None_ImageType", "object_ImageType"]
+)
+
+def test_validate_dicom_unexpected_image_type(image_type, expected_exc, expected_msg):
+    """THis method tests to see if the image type is unexpected"""
+    # Arrange
+    ds = Dataset()
+    ds.StudyID = "123"
+    ds.StudyDescription = "desc"
+    ds.ImageType = image_type
+    ds.Modality = "CT"
+
+    # Act & Assert
+    with pytest.raises(expected_exc) as excinfo:
+        dicom_utils.validate_dicom(ds)
+    assert expected_msg in str(excinfo.value)
+
+@pytest.mark.parametrize(
+    "modality_value, expected",
+    [
+        ("", True),
+        ("None", True),
+        ("MR", True),
+        ("ct", True),
+    ],
+    ids=["empty_modality", "none_modality", "MR_modality", "ct_modality"]
+)
+def test_validate_dicom_modality_edge_cases(modality_value, expected):
+    """This test is testing the Modality fields, like empty strings, None and different case variation"""
+    #Arrange
+    ds = Dataset()
+    ds.StudyID = "123"
+    ds.StudyDescription = "desc"
+    ds.ImageType = "AXIAL"
+    ds.Modality = modality_value
+
+    #Act
+    result = dicom_utils.validate_dicom(ds)
+
+    #Assert
+    assert result == expected

--- a/tests/test_input_and_outputs.py
+++ b/tests/test_input_and_outputs.py
@@ -1,0 +1,93 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from ntsecuritycon import DS_NAME_NO_ERROR
+from numba.core.callconv import excinfo_ptr_t
+
+from src import inputs_and_outputs
+
+@pytest.mark.parametrize(
+    "pixels, qimage, expected",
+    [
+        # Happy path
+        ("pixel_data", "QImage_object", "QImage_object"),
+    ],
+    ids=["happy_path"]
+)
+
+def test_get_qimage_from_dicom_file_success(pixels, qimage, expected):
+    """This module is getting the correct return value from the dicom file"""
+    ds = MagicMock()
+    with patch("src.inputs_and_outputs.get_normalized_pixel_array", return_value=pixels), \
+         patch("src.inputs_and_outputs.numpy_to_qimage", return_value=qimage):
+        result = inputs_and_outputs.get_qimage_from_dicom_file(ds)
+        assert result == expected
+
+@pytest.mark.parametrize(
+    "pixels, expected_exc, expected_msg",
+    [
+        (None, ValueError, "Failed to normalize pixel array"),
+    ],
+    ids=["normalise_returns_none"],
+)
+
+def test_get_qimage_from_dicom_file_failure(pixels, expected_exc, expected_msg):
+    """This method tests what happens when the get normalized pixel array returns none or an error"""
+    # Arrange
+    ds = MagicMock()
+    with patch("src.inputs_and_outputs.get_normalized_pixel_array", return_value=pixels):
+        # Act & Assert
+        with pytest.raises(expected_exc) as excinfo:
+            inputs_and_outputs.get_qimage_from_dicom_file(ds)
+        assert expected_msg in str(excinfo.value)
+
+@pytest.mark.parametrize(
+    "pixels, qimage, expected_exc, expected_msg",
+    [
+        # Edge case: numpy_to_qimage returns None
+        ("pixels_array", None, ValueError, "Failed to convert image to QImage"),
+    ],
+    ids=["qimage_returns_none"]
+)
+
+def test_get_qimage_from_dicom_file_qimage_none(qimage, pixels, expected_exc, expected_msg):
+    """This method is for checking rhe get_qimage_from_dicom_files returns an error when numpy_for qimage returns nothing is returned """
+    # Arrange
+    ds = MagicMock()
+    with patch("src.inputs_and_outputs.get_normalized_pixel_array", return_value=pixels), \
+         patch("src.inputs_and_outputs.numpy_to_qimage", return_value=qimage):
+
+        # Act & Assert
+        with pytest.raises(expected_exc) as excinfo:
+            inputs_and_outputs.get_qimage_from_dicom_file(ds)
+        assert expected_msg in str(excinfo.value)
+
+def test_get_qimage_from_dicom_file_att_error():
+    """This method checks that the get_qimage_from_dicom_file raises an error if there is no pixel data"""
+    dis = MagicMock()
+    with patch("src.inputs_and_outputs.get_normalized_pixel_array",
+               side_effect=AttributeError("no pixel data")):
+        with pytest.raises(ValueError) as excinfo:
+            inputs_and_outputs.get_qimage_from_dicom_file(dis)
+            assert "DICOM file is missing pixel data" in str(excinfo.value)
+
+def test_get_qimage_from_dicom_files_value_error():
+    """This method checks that get_qimage_from_dicom_file raises an error keeps the Value error raised by get_normalised_pixel_array
+    and that the error message is kept"""
+    #Arrange
+    ds = MagicMock()
+    with patch("src.inputs_and_outputs.get_normalized_pixel_array",side_effect=ValueError("bad value")):
+        with pytest.raises(ValueError) as excinfo:
+            inputs_and_outputs.get_qimage_from_dicom_file(ds)
+            assert "bad value" in str(excinfo.value)
+
+def test_get_qimage_from_dicom_file_unexpected_exception():
+
+    # arrange
+    ds = MagicMock()
+    with patch("src.inputs_and_outputs.get_normalized_pixel_array",
+               side_effect=RuntimeError("unexpected error")):
+        with pytest.raises(RuntimeError) as excinfo:
+            inputs_and_outputs.get_qimage_from_dicom_file(ds)
+            assert "unexpected error" in str(excinfo.value)
+            assert "Error loading DICOM file" in str(excinfo.value.__cause__)

--- a/tests/test_input_and_outputs.py
+++ b/tests/test_input_and_outputs.py
@@ -1,9 +1,5 @@
 import pytest
 from unittest.mock import patch, MagicMock
-
-from ntsecuritycon import DS_NAME_NO_ERROR
-from numba.core.callconv import excinfo_ptr_t
-
 from src import inputs_and_outputs
 
 @pytest.mark.parametrize(
@@ -21,7 +17,8 @@ def test_get_qimage_from_dicom_file_success(pixels, qimage, expected):
     with patch("src.inputs_and_outputs.get_normalized_pixel_array", return_value=pixels), \
          patch("src.inputs_and_outputs.numpy_to_qimage", return_value=qimage):
         result = inputs_and_outputs.get_qimage_from_dicom_file(ds)
-        assert result == expected
+
+    assert result == expected
 
 @pytest.mark.parametrize(
     "pixels, expected_exc, expected_msg",
@@ -39,7 +36,8 @@ def test_get_qimage_from_dicom_file_failure(pixels, expected_exc, expected_msg):
         # Act & Assert
         with pytest.raises(expected_exc) as excinfo:
             inputs_and_outputs.get_qimage_from_dicom_file(ds)
-        assert expected_msg in str(excinfo.value)
+
+    assert expected_msg in str(excinfo.value)
 
 @pytest.mark.parametrize(
     "pixels, qimage, expected_exc, expected_msg",
@@ -69,7 +67,8 @@ def test_get_qimage_from_dicom_file_att_error():
                side_effect=AttributeError("no pixel data")):
         with pytest.raises(ValueError) as excinfo:
             inputs_and_outputs.get_qimage_from_dicom_file(dis)
-            assert "DICOM file is missing pixel data" in str(excinfo.value)
+
+    assert "DICOM file is missing pixel data" in str(excinfo.value)
 
 def test_get_qimage_from_dicom_files_value_error():
     """This method checks that get_qimage_from_dicom_file raises an error keeps the Value error raised by get_normalised_pixel_array
@@ -79,7 +78,7 @@ def test_get_qimage_from_dicom_files_value_error():
     with patch("src.inputs_and_outputs.get_normalized_pixel_array",side_effect=ValueError("bad value")):
         with pytest.raises(ValueError) as excinfo:
             inputs_and_outputs.get_qimage_from_dicom_file(ds)
-            assert "bad value" in str(excinfo.value)
+    assert "bad value" in str(excinfo.value)
 
 def test_get_qimage_from_dicom_file_unexpected_exception():
 
@@ -88,6 +87,7 @@ def test_get_qimage_from_dicom_file_unexpected_exception():
     with patch("src.inputs_and_outputs.get_normalized_pixel_array",
                side_effect=RuntimeError("unexpected error")):
         with pytest.raises(RuntimeError) as excinfo:
-            inputs_and_outputs.get_qimage_from_dicom_file(ds)
-            assert "unexpected error" in str(excinfo.value)
-            assert "Error loading DICOM file" in str(excinfo.value.__cause__)
+                inputs_and_outputs.get_qimage_from_dicom_file(ds)
+        assert "Error loading DICOM image" in str(excinfo.value)
+        assert "unexpected error" in str(excinfo.value.__cause__)
+


### PR DESCRIPTION
Input and output
modified the import section to add src so the tests work
added some more unit testing for the file input_and output
not completed, jsut does one method:
testing:
- the return types in get_qimage_from_dicom_file
- the errors in get_qimage_from_dicom_file
- the if statements in get_qimage_from_dicom_file

dicom utils
Adding different tests to dicom_utils
testing:
-happy paths
- valid patient
- uuid patient
- invalid patient inputs
- missing fields
- incorrect date || type
- patient with a non UUID name
- missing required fields
- invalid image type
- skipping of non-AXIAL types
- multiple options per one
- unexpected image type
- unexpected things in modality

main_ui
added validate dicom_files because i missed it in my last upload and it was doing nothing

## Summary by Sourcery

Add comprehensive unit tests for DICOM file processing and validation in the project

New Features:
- Added unit tests for dicom_utils module
- Added unit tests for inputs_and_outputs module

Bug Fixes:
- Fixed import issues in input_and_outputs module
- Added missing validation for DICOM files in main UI

Enhancements:
- Improved error handling in DICOM file processing
- Added validation for DICOM file types and metadata

Tests:
- Created extensive test cases for patient information extraction
- Added test coverage for DICOM file validation
- Implemented tests for image conversion from DICOM files