### PR TITLE
dir input into the QFileDialog.getOpenFilename() call

### DIFF
--- a/src/mini_project_ui.py
+++ b/src/mini_project_ui.py
@@ -111,7 +111,7 @@ class MiniProjectUI(QtWidgets.QDialog):
 
     def add_directory(self):
         """Function for the button click""" 
-        dir_path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Select DICOM File",
+        dir_path, _ = QtWidgets.QFileDialog.getOpenFileName(self, caption="Select DICOM File", dir=str(pathlib.Path(self.path).parent),
                                                             filter="DICOM Files (*.dcm)")
         self.path = dir_path
         self.open_dicom_file()

--- a/src/mini_project_ui.py
+++ b/src/mini_project_ui.py
@@ -112,7 +112,12 @@ class MiniProjectUI(QtWidgets.QDialog):
     def add_directory(self):
         """Function for the button click"""
         path_object = pathlib.Path(self.path).parent
-        if not path_object.exists() or not path_object.is_dir() or self.path.strip() == "" or self.path is None:
+        if (
+                not path_object.exists()
+                or not path_object.is_dir()
+                or self.path.strip() == ""
+                or self.path is None
+        ):
             path_object = pathlib.Path.home()
         dir_path, _ = QtWidgets.QFileDialog.getOpenFileName(self,
                                                             caption="Select DICOM File",

--- a/src/mini_project_ui.py
+++ b/src/mini_project_ui.py
@@ -112,7 +112,7 @@ class MiniProjectUI(QtWidgets.QDialog):
     def add_directory(self):
         """Function for the button click"""
         path_object = pathlib.Path(self.path).parent
-        if not path_object.exists() or not path_object.is_dir():
+        if not path_object.exists() or not path_object.is_dir() or self.path.strip() == "" or self.path is None:
             path_object = pathlib.Path.home()
         dir_path, _ = QtWidgets.QFileDialog.getOpenFileName(self,
                                                             caption="Select DICOM File",

--- a/src/mini_project_ui.py
+++ b/src/mini_project_ui.py
@@ -111,7 +111,9 @@ class MiniProjectUI(QtWidgets.QDialog):
 
     def add_directory(self):
         """Function for the button click""" 
-        dir_path, _ = QtWidgets.QFileDialog.getOpenFileName(self, caption="Select DICOM File", dir=str(pathlib.Path(self.path).parent),
+        dir_path, _ = QtWidgets.QFileDialog.getOpenFileName(self,
+                                                            caption="Select DICOM File",
+                                                            dir=str(pathlib.Path(self.path).parent),
                                                             filter="DICOM Files (*.dcm)")
         self.path = dir_path
         self.open_dicom_file()

--- a/src/mini_project_ui.py
+++ b/src/mini_project_ui.py
@@ -127,8 +127,10 @@ class MiniProjectUI(QtWidgets.QDialog):
                                                             caption="Select DICOM File",
                                                             dir=str(path_object),
                                                             filter="DICOM Files (*.dcm)")
-        self.path = dir_path
-        self.open_dicom_file()
+        # on cancel getOpenFileName returns an empty string need to skip
+        if dir_path.strip() != "":
+            self.path = dir_path
+            self.open_dicom_file()
 
     #This also needs to be changed to reflect the MySQL
     def check_saved_dir(self):
@@ -168,7 +170,9 @@ class MiniProjectUI(QtWidgets.QDialog):
                 validate_dicom(ds)
             else:
                 logging.error("validate_dicom failed")
-                raise ValueError("Invalid DICOM file or failed to load the file.")
+                # just returning to avoid raising exception as exception is handled by not overwriting self.path if an empty string is the path
+                return
+                # raise ValueError("Invalid DICOM file or failed to load the file.")
 
             if ds is not None:
                 self.save_directory_path()

--- a/src/mini_project_ui.py
+++ b/src/mini_project_ui.py
@@ -110,10 +110,13 @@ class MiniProjectUI(QtWidgets.QDialog):
         self._grid_group_box.setLayout(layout)
 
     def add_directory(self):
-        """Function for the button click""" 
+        """Function for the button click"""
+        path_object = pathlib.Path(self.path).parent
+        if not path_object.exists() or not path_object.is_dir():
+            path_object = pathlib.Path.home()
         dir_path, _ = QtWidgets.QFileDialog.getOpenFileName(self,
                                                             caption="Select DICOM File",
-                                                            dir=str(pathlib.Path(self.path).parent),
+                                                            dir=str(path_object),
                                                             filter="DICOM Files (*.dcm)")
         self.path = dir_path
         self.open_dicom_file()

--- a/src/mini_project_ui.py
+++ b/src/mini_project_ui.py
@@ -111,14 +111,18 @@ class MiniProjectUI(QtWidgets.QDialog):
 
     def add_directory(self):
         """Function for the button click"""
+        if self.path is None: # To deal with if self.path is not initialized
+            self.path = ""
         path_object = pathlib.Path(self.path).parent
-        if (
+
+        if ( # To ensure the paths given are valid paths
                 not path_object.exists()
                 or not path_object.is_dir()
                 or self.path.strip() == ""
-                or self.path is None
         ):
+            # Sending to home directory if path doesn't exist
             path_object = pathlib.Path.home()
+
         dir_path, _ = QtWidgets.QFileDialog.getOpenFileName(self,
                                                             caption="Select DICOM File",
                                                             dir=str(path_object),

--- a/src/user_pref_controller.py
+++ b/src/user_pref_controller.py
@@ -2,16 +2,17 @@
 Class to access the API for the Database to Create directories
 for the storage of default user preferences
 """
-import pathlib # finding and creating directories
-import os # getting environment attributes
+import pathlib  # finding and creating directories
+import os  # getting environment attributes
 import sqlite3
-import subprocess # Running terminal code
-import logging # Logging what is happening in the code base
+import subprocess  # Running terminal code
+import logging  # Logging what is happening in the code base
 
 from src.user_pref_interface import UserPrefInterface
-from src.user_pref_model import UserPrefModel # accessing the database
+from src.user_pref_model import UserPrefModel  # accessing the database
 
-logger = logging.getLogger(__name__) # Starting logger
+logger = logging.getLogger(__name__)  # Starting logger
+
 
 class UserPrefController(UserPrefInterface):
     """
@@ -22,20 +23,33 @@ class UserPrefController(UserPrefInterface):
     #   True or Value means success
     #   False or exception means did not succeed
     # Unless otherwise Specified
-    def __init__(self, database_name:str="user_pref.db", database_location:pathlib.Path=pathlib.Path.home()) -> None:
-        """ Creating dependent classes and setting up the file system for the user """
+    def __init__(self,
+                 database_name: str = "user_pref.db",
+                 database_location: pathlib.Path = pathlib.Path.home()
+                 ) -> None:
+        """
+        Creating dependent classes and setting up the file system for the user
+        """
         logger.info("START: UserPreferences Database")
-        logger.debug("database_location: %s, database_name: %s", database_location, database_name)
-        self.db_location:pathlib.Path = database_location / ".onko" # database directory ( "." makes file hidden in linux and macOS)
+        logger.debug(
+            "database_location: %s, database_name: %s",
+            database_location, database_name
+        )
+        # database directory ( "." makes file hidden in linux and macOS)
+        self.db_location: pathlib.Path = database_location / ".onko"
         self.create_directory()
-        self.database_name:str=database_name
-        logger.debug("DB Location: %s, DB Name: %s", self.db_location, self.database_name)
-        self.user:str = "default" # Username for key
-        self.database:UserPrefModel = None  # Database access
+        self.database_name: str = database_name
+        logger.debug(
+            "DB Location: %s, DB Name: %s",
+            self.db_location,
+            self.database_name
+        )
+        self.user: str = "default"  # Username for key
+        self.database: UserPrefModel = None  # Database access
         logger.info("Finish UserPreferences Database")
 
     # Overwritten From Abstract Class
-    def save_default_path(self, path:pathlib.Path) -> bool:
+    def save_default_path(self, path: pathlib.Path) -> bool:
         """
         Saving a default path to the database
         returns true if path has been saved
@@ -47,7 +61,8 @@ class UserPrefController(UserPrefInterface):
             self.create_database_connection()
             self.set_default_directory(path)
         except sqlite3.OperationalError as error:
-            error_message = f"Failed to save default directory in save_default_path: {error}"
+            error_message = (f"Failed to save default directory "
+                             f"in save_default_path: {error}")
             logger.error(error_message)
             raise sqlite3.OperationalError(error_message) from error
         return True
@@ -61,7 +76,7 @@ class UserPrefController(UserPrefInterface):
         """
         self.create_database_connection()
         try:
-            directory:pathlib.Path = self.get_default_directory()
+            directory: pathlib.Path = self.get_default_directory()
             return directory
         except sqlite3.OperationalError as error:
             logger.error(error)
@@ -82,14 +97,28 @@ class UserPrefController(UserPrefInterface):
 
         # Skipping the rest of the function if the OS is not Windows
         if os.name != "nt":
-            logger.info("FINISHED: UserPreferences Directory: OS is not windows")
+            logger.info(
+                "FINISHED: UserPreferences Directory: OS is not windows"
+            )
             return True
         # Making Folder Hidden for Windows
         try:
-            subprocess.run(["attrib", "+h", str(self.db_location)], check=True, stderr=subprocess.PIPE, text=True)
-            logger.info("FINISHED: UserPreferences Directory: Windows Directory hidden")
+            subprocess.run(
+                ["attrib", "+h", str(self.db_location)],
+                check=True,
+                stderr=subprocess.PIPE,
+                text=True
+            )
+            logger.info(
+                "FINISHED: UserPreferences Directory: "
+                "Windows Directory hidden"
+            )
         except subprocess.CalledProcessError as error:
-            logger.warning(f"WARNING: UserPreferences Directory: Setting folder to hidden failed (non-critical), error: {error.stderr.strip()}. Continuing without hidden attribute.")
+            logger.warning(
+                "WARNING: UserPreferences Directory: "
+                "Setting folder to hidden failed (non-critical), "
+                "error: %s. Continuing without hidden attribute."
+                % str(error.stderr.strip()))
         return True
 
     def create_database_connection(self) -> None:
@@ -100,8 +129,14 @@ class UserPrefController(UserPrefInterface):
         try:
             logger.debug("database: %s", str(self.database))
             if self.database is None:
-                self.database:UserPrefModel = UserPrefModel(database_path=self.db_location, database_name=self.database_name)
-                logger.debug("database: %s", self.database.posix_database_location)
+                self.database: UserPrefModel = UserPrefModel(
+                    database_path=self.db_location,
+                    database_name=self.database_name
+                )
+                logger.debug(
+                    "database: %s",
+                    self.database.posix_database_location
+                )
             logger.info("FINISH: Creating Database Connection")
         except sqlite3.OperationalError as error:
             raise sqlite3.OperationalError from error
@@ -111,17 +146,29 @@ class UserPrefController(UserPrefInterface):
         Sets or changes the default directory in the database.
 
         Note:
-        Ensure that UserPrefModel.update_default_directory and UserPrefModel.add_default_directory
-        return Boolean values consistently representing the result of the operation.
+        Ensure that UserPrefModel.update_default_directory
+        and UserPrefModel.add_default_directory.
+        return Boolean values consistently
+        representing the result of the operation.
         """
         logger.info("START: UserPrefController Setting directory")
         try:
             if self.database.get_default_directory(user=self.user) is not None:
-                value:bool = self.database.update_default_directory(user=self.user, directory=path)
-                logger.info("FINISH: UserPreferences Setting Directory: Updated User")
+                value: bool = self.database.update_default_directory(
+                    user=self.user,
+                    directory=path
+                )
+                logger.info(
+                    "FINISH: UserPreferences Setting Directory: Updated User"
+                )
             else:
-                value:bool = self.database.add_default_directory(user=self.user, directory=path)
-                logger.info("FINISH: UserPreferences Setting Directory: Added User")
+                value: bool = self.database.add_default_directory(
+                    user=self.user,
+                    directory=path
+                )
+                logger.info(
+                    "FINISH: UserPreferences Setting Directory: Added User"
+                )
             return value
         except sqlite3.OperationalError as error:
             raise sqlite3.OperationalError from error
@@ -130,7 +177,11 @@ class UserPrefController(UserPrefInterface):
         """ Getting the user working directory"""
         logger.info("START: Getting Default Directory")
         try:
-            output:pathlib.Path = self.database.get_default_directory(user=self.user)
+            output: pathlib.Path = (
+                self.database.get_default_directory(
+                    user=self.user
+                )
+            )
             logger.info("FINISHED: Getting Default Directory")
         except sqlite3.OperationalError as error:
             raise sqlite3.OperationalError from error

--- a/src/user_pref_controller.py
+++ b/src/user_pref_controller.py
@@ -36,7 +36,7 @@ class UserPrefController(UserPrefInterface):
             database_location, database_name
         )
         # database directory ( "." makes file hidden in linux and macOS)
-        self.db_location: pathlib.Path = database_location / ".onko"
+        self.db_location: pathlib.Path = database_location.joinpath(".onko")
         self.create_directory()
         self.database_name: str = database_name
         logger.debug(
@@ -154,7 +154,7 @@ class UserPrefController(UserPrefInterface):
         logger.info("START: UserPrefController Setting directory")
         try:
             if self.database.get_default_directory(user=self.user) is not None:
-                value: bool = self.database.update_default_directory(
+                default_change_success: bool = self.database.update_default_directory(
                     user=self.user,
                     directory=path
                 )
@@ -162,14 +162,14 @@ class UserPrefController(UserPrefInterface):
                     "FINISH: UserPreferences Setting Directory: Updated User"
                 )
             else:
-                value: bool = self.database.add_default_directory(
+                default_change_success: bool = self.database.add_default_directory(
                     user=self.user,
                     directory=path
                 )
                 logger.info(
                     "FINISH: UserPreferences Setting Directory: Added User"
                 )
-            return value
+            return default_change_success
         except sqlite3.OperationalError as error:
             raise sqlite3.OperationalError from error
 

--- a/src/user_pref_controller.py
+++ b/src/user_pref_controller.py
@@ -117,8 +117,8 @@ class UserPrefController(UserPrefInterface):
             logger.warning(
                 "WARNING: UserPreferences Directory: "
                 "Setting folder to hidden failed (non-critical), "
-                "error: %s. Continuing without hidden attribute."
-                % str(error.stderr.strip()))
+                "error: %s. Continuing without hidden attribute.",
+                str(error.stderr.strip()))
         return True
 
     def create_database_connection(self) -> None:

--- a/src/user_pref_interface.py
+++ b/src/user_pref_interface.py
@@ -5,19 +5,19 @@ to access the UserPreferences Class
 import pathlib
 from abc import ABC, abstractmethod
 
+
 class UserPrefInterface(ABC):
     """
     Abstract class to define methods to
     access the UserPreferences Class
     """
     @abstractmethod
-    def save_default_path(self, path:pathlib.Path) -> bool:
+    def save_default_path(self, path: pathlib.Path) -> bool:
         """
         Saving a default path to the database
         returns true if path has been saved
         else False
         """
-        pass
 
     @abstractmethod
     def default_path(self) -> pathlib.Path | None:
@@ -26,4 +26,3 @@ class UserPrefInterface(ABC):
         A check is likely Required before using this method
         to ensure that a default path exists
         """
-        pass

--- a/src/user_pref_model.py
+++ b/src/user_pref_model.py
@@ -3,7 +3,8 @@ import sqlite3
 import logging
 import pathlib
 
-logger = logging.getLogger(__name__) # Starting Logger
+logger = logging.getLogger(__name__)  # Starting Logger
+
 
 class UserPrefModel:
     """ class to create a user preferences database """
@@ -12,20 +13,20 @@ class UserPrefModel:
     #   True or Value indicates ran correctly
     #   False indicates operational Error
 
-    def __init__(self, database_path:pathlib.Path, database_name: str):
+    def __init__(self, database_path: pathlib.Path, database_name: str):
         """ Initializing the database connection/creating database """
         logger.info("Initializing the database connection/creating database")
         # appending database name to database path
-        self.database_location:pathlib.Path = database_path / database_name
-        self.max_username_length:int = 20
-        self.max_directory_length:int = 200
-        # converting to posix cause sqlite3 seems to not like taking a pathlib.Path object as an input
-        self.posix_database_location:str = self.database_location.as_posix()
+        self.database_location: pathlib.Path = database_path / database_name
+        self.max_username_length: int = 20
+        self.max_directory_length: int = 200
+        # converting to posix cause sqlite3 seems to not like
+        # taking a pathlib.Path object as an input
+        self.posix_database_location: str = self.database_location.as_posix()
         logger.debug("database location: %s", self.posix_database_location)
 
         self.create_table()
         logger.info("Database connection successful")
-
 
     def create_table(self) -> bool:
         """ Creating table in database"""
@@ -33,7 +34,7 @@ class UserPrefModel:
         try:
             with sqlite3.connect(self.posix_database_location) as base:
                 base.execute(
-                "CREATE TABLE IF NOT EXISTS user_preferences ("
+                    "CREATE TABLE IF NOT EXISTS user_preferences ("
                     "username TEXT UNIQUE PRIMARY KEY, "
                     "default_dir TEXT"
                     ")"
@@ -45,15 +46,19 @@ class UserPrefModel:
             raise sqlite3.OperationalError from error
 
     def get_default_directory(self, user: str) -> pathlib.Path | None:
+        """ This is to get the default directory for a specific user """
         logger.info("Getting default_directory from database")
         try:
             with sqlite3.connect(self.posix_database_location) as base:
-                value:str = base.execute(
-                    "SELECT default_dir FROM user_preferences WHERE username = ?",
-                [user]
+                value: str = base.execute(
+                    "SELECT default_dir "
+                    "FROM user_preferences "
+                    "WHERE username = ?",
+                    [user]
                 ).fetchone()
                 logger.debug("output value %s:", value)
-                # return None is no value is present otherwise return the values found
+                # return None is no value is present
+                # otherwise return the values found
                 if value is None:
                     logger.info("No default directory found")
                     return None
@@ -63,27 +68,33 @@ class UserPrefModel:
             logger.error("Directory not fetched from database")
             raise sqlite3.OperationalError from error
 
-    def _input_check(self, user: str, directory:pathlib.Path) -> None:
+    def _input_check(self, user: str, directory: pathlib.Path) -> None:
         """ To check is the lengths of the inputs are appropriate and exist """
         if (
             not user
             or directory is None
-            or user.__len__() > self.max_username_length
+            or len(user) > self.max_username_length
             or directory == pathlib.Path("")
             or len(str(directory)) > self.max_directory_length
         ):
             logger.error("Invalid User or Directory Name")
             raise RuntimeError("Error: Invalid Directory Name")
 
-    def add_default_directory(self, user: str, directory:pathlib.Path) -> bool:
+    def add_default_directory(
+            self,
+            user: str,
+            directory: pathlib.Path
+    ) -> bool:
         """ adding an entry into the user_preferences table """
         logger.info("Adding user to database")
         self._input_check(user, directory)
         try:
             with sqlite3.connect(self.posix_database_location) as base:
-                directory:str = str(directory)
+                directory: str = str(directory)
                 base.execute(
-                    "INSERT OR IGNORE INTO user_preferences(username, default_dir) VALUES (?, ?)",
+                    "INSERT OR IGNORE "
+                    "INTO user_preferences(username, default_dir) "
+                    "VALUES (?, ?)",
                     [user, directory]
                 )
                 logger.info("User added successfully")
@@ -92,15 +103,21 @@ class UserPrefModel:
             logger.error("OperationalError")
             raise sqlite3.OperationalError from error
 
-    def update_default_directory(self, user:str, directory:pathlib.Path) -> bool:
+    def update_default_directory(
+            self,
+            user: str,
+            directory: pathlib.Path
+    ) -> bool:
         """ updating an existing entry to the user_preferences table """
         logger.info("Updating user to database")
         self._input_check(user, directory)
         try:
             with sqlite3.connect(self.posix_database_location) as base:
-                directory:str = str(directory)
+                directory: str = str(directory)
                 base.execute(
-                    "UPDATE user_preferences SET default_dir= ? WHERE username= ? ",
+                    "UPDATE user_preferences "
+                    "SET default_dir= ? "
+                    "WHERE username= ? ",
                     [directory, user]
                 )
                 logger.info("Directory Updated successfully")
@@ -109,7 +126,7 @@ class UserPrefModel:
             logger.error("OperationalError")
             raise sqlite3.OperationalError from error
 
-    def delete_default_directory(self, user:str) -> bool:
+    def delete_default_directory(self, user: str) -> bool:
         """ deleting an existing entry from the user_preferences table """
         logger.info("Deleting directory to database")
         try:

--- a/tests/test_user_pref_controller.py
+++ b/tests/test_user_pref_controller.py
@@ -1,30 +1,46 @@
-import pytest
+""" Test File for user_pref_controller file """
 import logging
-import sqlite3
 import pathlib
+# import sqlite3
 from typing import Any, Generator
+import pytest
 from src.user_pref_controller import UserPrefController
 from src.user_pref_model import UserPrefModel
 
 logger = logging.getLogger(__name__)
 logger.debug("UnitTests: UserPrefModel")
 
+
 class TestUserPrefController:
     """ Test Class for UserPrefController """
     @pytest.fixture(scope="function")
-    def access(self, tmp_path:pathlib.Path) -> Generator[UserPrefController, Any, None]:
-        """ Fixture to set up the Database environment for the tests to run in """
-        yield UserPrefController(database_location=tmp_path, database_name="test_db.db")
-
+    def access(
+            self,
+            tmp_path: pathlib.Path
+    ) -> Generator[UserPrefController, Any, None]:
+        """
+        Fixture to set up the Database environment for the tests to run in
+        """
+        yield UserPrefController(
+            database_location=tmp_path,
+            database_name="test_db.db"
+        )
 
     @pytest.fixture(scope="function")
-    def fix_create_dir(self, access:UserPrefController) -> 'Generator[UserPrefController, Any, None]':
+    def fix_create_dir(
+            self,
+            access: UserPrefController
+    ) -> 'Generator[UserPrefController, Any, None]':
         """ Fixture to create a directory in which the tests are running in """
         access.create_directory()
         yield access
 
     @pytest.fixture(scope="function")
-    def fix_setup_db(self, tmp_path, access:UserPrefController) -> Generator[UserPrefController, Any, None]:
+    def fix_setup_db(
+            self,
+            tmp_path,
+            access: UserPrefController
+    ) -> Generator[UserPrefController, Any, None]:
         """ Fixture to update user preferences """
         logger.debug("Setting up Database")
         access.create_directory()
@@ -32,20 +48,35 @@ class TestUserPrefController:
         access.set_default_directory(tmp_path)
         yield access
 
-    def test_save_default_path(self, tmp_path:pathlib.Path) -> None:
+    def test_save_default_path(self, tmp_path: pathlib.Path) -> None:
         """ Test method for the save default path method """
-        use:UserPrefController = UserPrefController(database_location=tmp_path, database_name="test_db.db")
+        use: UserPrefController = UserPrefController(
+            database_location=tmp_path,
+            database_name="test_db.db"
+        )
         assert use.save_default_path(tmp_path)
         assert use.default_path() == tmp_path
 
-    def test_default_path(self, tmp_path, fix_setup_db:UserPrefController) -> None:
+    def test_default_path(
+            self,
+            tmp_path,
+            fix_setup_db: UserPrefController
+    ) -> None:
         """ Test method for the default path method """
         assert fix_setup_db.default_path() == tmp_path
-        second: UserPrefController = UserPrefController(database_name="test_db2.db", database_location=tmp_path)
+        second: UserPrefController = UserPrefController(
+            database_name="test_db2.db",
+            database_location=tmp_path
+        )
         assert second.default_path() is None
 
-    def test_default_path_when_not_set(self, fix_create_dir:UserPrefController) -> None:
-        """ Test method for the default path method if no default path is set """
+    def test_default_path_when_not_set(
+            self,
+            fix_create_dir: UserPrefController
+    ) -> None:
+        """
+        Test method for the default path method if no default path is set
+        """
         assert fix_create_dir.default_path() is None
 
     def test_create_directory(self, access: UserPrefController) -> None:
@@ -55,35 +86,55 @@ class TestUserPrefController:
         created_dir = access.db_location
         assert created_dir.exists() and created_dir.is_dir()
 
-    def test_create_database_connection(self, access:UserPrefController) -> None:
+    def test_create_database_connection(
+            self,
+            access: UserPrefController
+    ) -> None:
         """ Testing for if the Class Creates an instance of UserPrefModel """
         access.create_directory()
         access.create_database_connection()
         assert isinstance(access.database, UserPrefModel)
 
-    def test_set_default_directory(self, tmp_path, fix_setup_db:UserPrefController) -> None:
+    def test_set_default_directory(
+            self,
+            tmp_path,
+            fix_setup_db: UserPrefController
+    ) -> None:
         """ Testing to see if Adding Directory branch works """
-        temp_dir:pathlib.Path = tmp_path
+        temp_dir: pathlib.Path = tmp_path
         assert fix_setup_db.set_default_directory(temp_dir)
 
-    def test_update_default_directory(self, tmp_path, fix_setup_db:UserPrefController) -> None:
+    def test_update_default_directory(
+            self,
+            tmp_path,
+            fix_setup_db: UserPrefController
+    ) -> None:
         """ Testing to see if updating Directory branch works """
-        temp_dir:pathlib.Path = tmp_path / "test_db"
+        temp_dir: pathlib.Path = tmp_path / "test_db"
         assert fix_setup_db.set_default_directory(temp_dir)
 
-    def test_get_default_directory(self, tmp_path, fix_setup_db:UserPrefController) -> None:
+    def test_get_default_directory(
+            self,
+            tmp_path,
+            fix_setup_db: UserPrefController
+    ) -> None:
         """ Test method for the get_default_directory method """
-        logging.debug("testpath:", tmp_path)
+        logging.debug("testpath: %s", str(tmp_path))
         assert fix_setup_db.get_default_directory() == tmp_path
 
-        ## Don't know why but this section of code when create directory is working in the UserPref Controller causes an error
+        # Don't know why but this section of code when create directory
+        # is working in the UserPref Controller causes an error
         # temp_dir2: pathlib.Path = tmp_path
         # with pytest.raises(sqlite3.OperationalError) as invalid_dir:
-        #     new_db_dir:UserPrefController = UserPrefController(database_location=temp_dir2, database_name="test_db.db")
-        # #     new_db_dir.create_database_connection()
-        # #     new_db_dir.get_default_directory()
-        # # logging.debug("test_get_directory: %s", invalid_dir.value)
+        #     new_db_dir:UserPrefController = UserPrefController(
+        #         database_location=temp_dir2,
+        #         database_name="test_db.db"
+        #     )
+        #     new_db_dir.create_database_connection()
+        #     new_db_dir.get_default_directory()
+        # logging.debug("test_get_directory: %s", invalid_dir.value)
         # assert isinstance(invalid_dir.value, sqlite3.OperationalError)
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/tests/test_user_pref_controller.py
+++ b/tests/test_user_pref_controller.py
@@ -14,7 +14,7 @@ logger.debug("UnitTests: UserPrefModel")
 class TestUserPrefController:
     """ Test Class for UserPrefController """
     @pytest.fixture(scope="function")
-    def access(
+    def base_fixture(
             self,
             tmp_path: pathlib.Path
     ) -> Generator[UserPrefController, Any, None]:
@@ -27,26 +27,26 @@ class TestUserPrefController:
         )
 
     @pytest.fixture(scope="function")
-    def fix_create_dir(
+    def fixture_create_dir(
             self,
-            access: UserPrefController
+            base_fixture: UserPrefController
     ) -> 'Generator[UserPrefController, Any, None]':
         """ Fixture to create a directory in which the tests are running in """
-        access.create_directory()
-        yield access
+        base_fixture.create_directory()
+        yield base_fixture
 
     @pytest.fixture(scope="function")
-    def fix_setup_db(
+    def fixture_setup_database(
             self,
             tmp_path,
-            access: UserPrefController
+            base_fixture: UserPrefController
     ) -> Generator[UserPrefController, Any, None]:
         """ Fixture to update user preferences """
         logger.debug("Setting up Database")
-        access.create_directory()
-        access.create_database_connection()
-        access.set_default_directory(tmp_path)
-        yield access
+        base_fixture.create_directory()
+        base_fixture.create_database_connection()
+        base_fixture.set_default_directory(tmp_path)
+        yield base_fixture
 
     def test_save_default_path(self, tmp_path: pathlib.Path) -> None:
         """ Test method for the save default path method """
@@ -60,10 +60,10 @@ class TestUserPrefController:
     def test_default_path(
             self,
             tmp_path,
-            fix_setup_db: UserPrefController
+            fixture_setup_database: UserPrefController
     ) -> None:
         """ Test method for the default path method """
-        assert fix_setup_db.default_path() == tmp_path
+        assert fixture_setup_database.default_path() == tmp_path
         second: UserPrefController = UserPrefController(
             database_name="test_db2.db",
             database_location=tmp_path
@@ -72,55 +72,55 @@ class TestUserPrefController:
 
     def test_default_path_when_not_set(
             self,
-            fix_create_dir: UserPrefController
+            fixture_create_dir: UserPrefController
     ) -> None:
         """
         Test method for the default path method if no default path is set
         """
-        assert fix_create_dir.default_path() is None
+        assert fixture_create_dir.default_path() is None
 
-    def test_create_directory(self, access: UserPrefController) -> None:
+    def test_create_directory(self, base_fixture: UserPrefController) -> None:
         """ Test method for the create directory method """
-        assert access.create_directory()
+        assert base_fixture.create_directory()
         # Verify the directory was actually created on disk
-        created_dir = access.db_location
+        created_dir = base_fixture.db_location
         assert created_dir.exists() and created_dir.is_dir()
 
     def test_create_database_connection(
             self,
-            access: UserPrefController
+            base_fixture: UserPrefController
     ) -> None:
         """ Testing for if the Class Creates an instance of UserPrefModel """
-        access.create_directory()
-        access.create_database_connection()
-        assert isinstance(access.database, UserPrefModel)
+        base_fixture.create_directory()
+        base_fixture.create_database_connection()
+        assert isinstance(base_fixture.database, UserPrefModel)
 
     def test_set_default_directory(
             self,
             tmp_path,
-            fix_setup_db: UserPrefController
+            fixture_setup_database: UserPrefController
     ) -> None:
         """ Testing to see if Adding Directory branch works """
         temp_dir: pathlib.Path = tmp_path
-        assert fix_setup_db.set_default_directory(temp_dir)
+        assert fixture_setup_database.set_default_directory(temp_dir)
 
     def test_update_default_directory(
             self,
             tmp_path,
-            fix_setup_db: UserPrefController
+            fixture_setup_database: UserPrefController
     ) -> None:
         """ Testing to see if updating Directory branch works """
         temp_dir: pathlib.Path = tmp_path / "test_db"
-        assert fix_setup_db.set_default_directory(temp_dir)
+        assert fixture_setup_database.set_default_directory(temp_dir)
 
     def test_get_default_directory(
             self,
             tmp_path,
-            fix_setup_db: UserPrefController
+            fixture_setup_database: UserPrefController
     ) -> None:
         """ Test method for the get_default_directory method """
         logging.debug("testpath: %s", str(tmp_path))
-        assert fix_setup_db.get_default_directory() == tmp_path
+        assert fixture_setup_database.get_default_directory() == tmp_path
 
         # Don't know why but this section of code when create directory
         # is working in the UserPref Controller causes an error

--- a/tests/test_user_pref_model.py
+++ b/tests/test_user_pref_model.py
@@ -1,21 +1,22 @@
 """ Test File for the user_pref_model file """
 import pathlib
-import pytest
 import logging
+import pytest
 from src.user_pref_model import UserPrefModel
 
 logger = logging.getLogger(__name__)
 logger.debug("UnitTests: UserPrefModel")
 
+
 class TestUserPrefModel:
     """ Test Class for UserPrefModel """
     @pytest.fixture
     def access(self, tmp_path):
-        logger.setLevel(logging.DEBUG)
         """ Fixture to set up and Teardown tests """
         logging.info('Setting up test DB fixture')
         yield UserPrefModel(database_path=tmp_path, database_name="test_db.db")
         logging.info('Teardown test DB fixture')
+
     def test_create_table(self, access):
         """ Test Method for create Table method """
         assert access.create_table() == 1
@@ -70,7 +71,10 @@ class TestUserPrefModel:
         assert str(invalid_user.value) == "Error: Invalid Directory Name"
         long_dir = "p" * 300
         with pytest.raises(RuntimeError) as invalid_dir:
-            access.update_default_directory("ValidUser", pathlib.Path(long_dir))
+            access.update_default_directory(
+                "ValidUser",
+                pathlib.Path(long_dir)
+            )
         assert str(invalid_dir.value) == "Error: Invalid Directory Name"
 
     def test_delete_default_directory(self, tmp_path, access):
@@ -79,6 +83,7 @@ class TestUserPrefModel:
         assert access.delete_default_directory("Dan")
         assert access.get_default_directory("Dan") is None
         assert access.delete_default_directory("Dom")
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
**added:**
- dir input into the QFileDialog.getOpenFilename() call
- Handled Exception on cancelling open file dialog

this change was made so that when reopening the program it goes back to the last directory a file was opened from

## Summary by Sourcery

Enhancements:
- Initialize QFileDialog.getOpenFileName with the last used directory as its starting path